### PR TITLE
:construction_worker: Setup GitHub Actions Continuous Integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,6 @@ jobs:
           environment-name: chabud
           environment-file: conda-lock.yml
 
-      # Show installed packages
-      - name: List installed packages
-        run: micromamba list
-
       # Run the unit tests
       - name: Test with pytest
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,6 @@ jobs:
       matrix:
         python-version: ["3.11"]
         os: [ubuntu-22.04]
-    defaults:
-      run:
-        shell: bash -l {0}
 
     steps:
       # Checkout current git repository
@@ -32,13 +29,10 @@ jobs:
 
       # Install Micromamba with conda-forge dependencies
       - name: Setup Micromamba
-        uses: mamba-org/provision-with-micromamba@e2b397b12d0a38069451664382b769c9456e3d6d # v15
+        uses: mamba-org/setup-micromamba@1887e3afc05fd11eb40c9542c2939ac04234546e # v1.2.1
         with:
           environment-name: chabud
           environment-file: conda-lock.yml
-          extra-specs: |
-            python=${{ matrix.python-version }}
-            pytest
 
       # Show installed packages
       - name: List installed packages
@@ -46,4 +40,7 @@ jobs:
 
       # Run the unit tests
       - name: Test with pytest
-        run: python -m pytest --verbose chabud/tests/
+        run: |
+            micromamba install python=${{ matrix.python-version }} pytest
+            python -m pytest --verbose chabud/tests/
+        shell: micromamba-shell {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
       matrix:
         python-version: ["3.11"]
         os: [ubuntu-22.04]
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
       # Checkout current git repository
@@ -39,4 +42,3 @@ jobs:
         run: |
             micromamba install python=${{ matrix.python-version }} pytest
             python -m pytest --verbose chabud/tests/
-        shell: micromamba-shell {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+# This workflow will install Python dependencies and run tests on a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Test
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+        os: [ubuntu-22.04]
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      # Checkout current git repository
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      # Install Micromamba with conda-forge dependencies
+      - name: Setup Micromamba
+        uses: mamba-org/provision-with-micromamba@e2b397b12d0a38069451664382b769c9456e3d6d # v15
+        with:
+          environment-file: conda-lock.yml
+          extra-specs: |
+            python=${{ matrix.python-version }}
+            pytest
+
+      # Show installed packages
+      - name: List installed packages
+        run: micromamba list
+
+      # Run the unit tests
+      - name: Test with pytest
+        run: python -m pytest --verbose chabud/tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Setup Micromamba
         uses: mamba-org/provision-with-micromamba@e2b397b12d0a38069451664382b769c9456e3d6d # v15
         with:
+          environment-name: chabud
           environment-file: conda-lock.yml
           extra-specs: |
             python=${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+
 # Data files and folders
 data/**
 !data/**/
+
+# Unit test / coverage reports
+.pytest_cache/

--- a/chabud/tests/test_datapipe.py
+++ b/chabud/tests/test_datapipe.py
@@ -1,0 +1,33 @@
+import lightning as L
+import torch
+
+from chabud.datapipe import ChaBuDDataPipeModule
+
+
+# %%
+def test_datapipemodule():
+    """
+    Ensure that ChaBuDDataPipeModule works to load data from a nested HDF5 file
+    into torch.Tensor and list objects.
+    """
+    datamodule: L.LightningDataModule = ChaBuDDataPipeModule(
+        hdf5_urls=[
+            "https://huggingface.co/datasets/chabud-team/chabud-extra/resolve/main/california_2.hdf5"
+        ]
+    )
+    datamodule.setup()
+
+    it = iter(datamodule.train_dataloader())
+    pre_image, post_image, mask, metadata = next(it)
+
+    assert pre_image.shape == (32, 512, 512, 12)
+    assert pre_image.dtype == torch.int16
+
+    assert post_image.shape == (32, 512, 512, 12)
+    assert post_image.dtype == torch.int16
+
+    assert mask.shape == (32, 512, 512)
+    assert mask.dtype == torch.uint8
+
+    assert len(metadata) == 32
+    assert set(metadata[0].keys()) == {"filename", "uuid"}


### PR DESCRIPTION

## What I am changing
<!-- What were the high-level goals of the change? -->
- Add Continuous Integration tests for every Pull Request and push to the `main` branch

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Added an integration test under `chabud/tests/test_datapipe.py` to ensure ChaBuDDataPipeModule works
- Add GitHub Actions workflow in `.github/workflows/test.yml` which runs on Ubuntu-22.04 and Python 3.11
  - Uses https://github.com/mamba-org/setup-micromamba to install dependencies
  - Note that the `conda-lock.yml` lockfile is used, since `micromamba` support it! However, we're installing `pytest` separately instead of adding it to the `environment.yml` file.
- Also gitignoring `__pycache__/` and `pytest_cache/` folders

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Install `pytest` and run `python -m pytest --verbose chabud/tests/` locally

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
Based on https://github.com/weiji14/zen3geo/pull/2 and code from the private `ml-pipeline` repo.
