### PR TITLE
:recycle: Refactor to change tensors from channel last to channel first

### DIFF
--- a/chabud/README.md
+++ b/chabud/README.md
@@ -1,0 +1,9 @@
+# ChaBuD Python modules
+
+This folder contains Python scripts used to pre-process satellite data, as well
+as the neural network model architecture, data loaders, and training/testing
+scripts. To ensure high standards of reproducibility, the code is structured
+using the [Lightning](https://lightning.ai/pytorch-lightning) framework and
+based on https://github.com/Lightning-AI/deep-learning-project-template.
+
+- :bricks: datapipe.py - Data pipeline to load Sentinel-2 optical imagery from HDF5 files and perform pre-processing

--- a/chabud/tests/test_datapipe.py
+++ b/chabud/tests/test_datapipe.py
@@ -20,10 +20,10 @@ def test_datapipemodule():
     it = iter(datamodule.train_dataloader())
     pre_image, post_image, mask, metadata = next(it)
 
-    assert pre_image.shape == (32, 512, 512, 12)
+    assert pre_image.shape == (32, 12, 512, 512)
     assert pre_image.dtype == torch.int16
 
-    assert post_image.shape == (32, 512, 512, 12)
+    assert post_image.shape == (32, 12, 512, 512)
     assert post_image.dtype == torch.int16
 
     assert mask.shape == (32, 512, 512)


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Reordering the chip dimensions to be (12, 512, 512) instead of (512, 512, 12).

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Modified the `_datatree_to_chip` function while the tensor is still in an xarray.Dataset format.
- Note that only the `pre_fire` and `post_fire` tensors are reshaped to (12, 512, 512). The `mask` tensor remains (512, 512).

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `python -m pytest chabud/tests/` to run the unit tests that capture this change.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Also added a README.md to the chabud/ folder describing the contents.

Patches #4