### PR TITLE
:building_construction: Initialize ChaBuDNet model architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,9 @@ __pycache__/
 data/**
 !data/**/
 
+# Pytorch Lightning checkpoints
+checkpoints/*.ckpt
+lightning_logs/
+
 # Unit test / coverage reports
 .pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ __pycache__/
 data/**
 !data/**/
 
-# Pytorch Lightning checkpoints
+# Lightning checkpoints
 checkpoints/*.ckpt
 lightning_logs/
 

--- a/chabud/README.md
+++ b/chabud/README.md
@@ -7,3 +7,4 @@ using the [Lightning](https://lightning.ai/pytorch-lightning) framework and
 based on https://github.com/Lightning-AI/deep-learning-project-template.
 
 - :bricks: datapipe.py - Data pipeline to load Sentinel-2 optical imagery from HDF5 files and perform pre-processing
+- :spider_web: model.py - Code containing Neural Network model architecture

--- a/chabud/model.py
+++ b/chabud/model.py
@@ -1,8 +1,8 @@
 """
 ChaBuDNet model architecture code.
 
-Code structure adapted from Pytorch Lightning project seed at
-https://github.com/PyTorchLightning/deep-learning-project-template
+Code structure adapted from Lightning project seed at
+https://github.com/Lightning-AI/deep-learning-project-template
 """
 
 import lightning as L
@@ -19,9 +19,14 @@ class ChaBuDNet(L.LightningModule):
     Implemented using Lightning 2.0.
     """
 
-    def __init__(self):
+    def __init__(self, lr: float = 0.001):
         """
         Define layers of the ChaBuDNet model.
+
+        Parameters
+        ----------
+        lr : float
+            The learning rate for the Adam optimizer. Default is 0.001.
         """
         super().__init__()
 
@@ -127,7 +132,7 @@ class ChaBuDNet(L.LightningModule):
         Optimizing function used to reduce the loss, so that the predicted
         mask gets as close as possible to the groundtruth mask.
 
-        Using the Adam optimizer with a learning rate of 0.01. See:
+        Using the Adam optimizer with a learning rate of 0.001. See:
 
         - Kingma, D. P., & Ba, J. (2017). Adam: A Method for Stochastic
           Optimization. ArXiv:1412.6980 [Cs]. http://arxiv.org/abs/1412.6980
@@ -135,4 +140,4 @@ class ChaBuDNet(L.LightningModule):
         Documentation at:
         https://lightning.ai/docs/pytorch/2.0.2/common/lightning_module.html#configure-optimizers
         """
-        return torch.optim.Adam(params=self.parameters(), lr=0.01)
+        return torch.optim.Adam(params=self.parameters(), lr=self.hparams.lr)

--- a/chabud/model.py
+++ b/chabud/model.py
@@ -1,0 +1,138 @@
+"""
+ChaBuDNet model architecture code.
+
+Code structure adapted from Pytorch Lightning project seed at
+https://github.com/PyTorchLightning/deep-learning-project-template
+"""
+
+import lightning as L
+import torch
+import torchmetrics
+
+
+# %%
+class ChaBuDNet(L.LightningModule):
+    """
+    Neural network for performing Change detection for Burned area Delineation
+    (ChaBuD) on Sentinel 2 optical satellite imagery.
+
+    Implemented using Lightning 2.0.
+    """
+
+    def __init__(self):
+        """
+        Define layers of the ChaBuDNet model.
+        """
+        super().__init__()
+
+        # Save hyperparameters like lr, weight_decay, etc to self.hparams
+        # https://pytorch-lightning.readthedocs.io/en/2.0.2/common/lightning_module.html#save-hyperparameters
+        self.save_hyperparameters(logger=True)
+
+        # First input convolution with same number of groups as input channels
+        self.input_conv = torch.nn.Sequential(
+            torch.nn.Conv2d(
+                in_channels=24, out_channels=64, kernel_size=3, padding=1, groups=4
+            ),
+            torch.nn.SiLU(),
+        )
+
+        # TODO Get backbone architecture from some model zoo
+        # self.backbone = ()
+
+        # Output layers
+        self.output_conv = torch.nn.Conv2d(
+            in_channels=64, out_channels=1, kernel_size=3, padding=1, groups=1
+        )
+
+        # Loss functions
+        self.loss_bce = torch.nn.BCEWithLogitsLoss(reduction="mean")
+
+        # Evaluation metrics to know how good the segmentation results are
+        self.iou = torchmetrics.JaccardIndex(task="binary", num_classes=2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass (Inference/Prediction).
+        """
+        x_: torch.Tensor = self.input_conv(x)
+        # x_: torch.Tensor = self.backbone(x_)
+        y_hat: torch.Tensor = self.output_conv(x_)
+
+        return y_hat.squeeze()
+
+    def training_step(
+        self,
+        batch: tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict],
+        batch_idx: int,
+    ) -> torch.Tensor:
+        """
+        Logic for the neural network's training loop.
+        """
+        dtype = torch.float16 if "16" in self.trainer.precision else torch.float32
+        pre_img, post_img, mask, metadata = batch
+
+        # Pass the image through neural network model to get predicted images
+        x: torch.Tensor = torch.concat(tensors=[pre_img, post_img], dim=1).to(
+            dtype=dtype
+        )
+        # assert x.shape == (32, 24, 512, 512)
+        y_hat: torch.Tensor = self(x=x)
+        # assert y_hat.shape == mask.shape == (32, 512, 512)
+
+        # Log training loss and metrics
+        loss: torch.Tensor = self.loss_bce(input=y_hat, target=mask.to(dtype=dtype))
+        metric: torch.Tensor = self.iou(preds=y_hat, target=mask)
+        self.log_dict(
+            dictionary={"train/loss_bce": loss, "train/iou": metric},
+            on_step=True,
+            on_epoch=False,
+            prog_bar=True,
+        )
+
+        return loss
+
+    def validation_step(
+        self,
+        batch: tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict],
+        batch_idx: int,
+    ) -> torch.Tensor:
+        """
+        Logic for the neural network's validation loop.
+        """
+        dtype = torch.float16 if "16" in self.trainer.precision else torch.float32
+        pre_img, post_img, mask, metadata = batch
+
+        # Pass the image through neural network model to get predicted images
+        x: torch.Tensor = torch.concat(tensors=[pre_img, post_img], dim=1).to(
+            dtype=dtype
+        )
+        # assert x.shape == (32, 24, 512, 512)
+        y_hat: torch.Tensor = self(x=x)
+        # assert y_hat.shape == mask.shape == (32, 512, 512)
+
+        # Log validation loss and metrics
+        loss: torch.Tensor = self.loss_bce(input=y_hat, target=mask.to(dtype=dtype))
+        metric: torch.Tensor = self.iou(preds=y_hat, target=mask)
+        self.log_dict(
+            dictionary={"val/loss_bce": loss, "val/iou": metric},
+            on_step=True,
+            on_epoch=False,
+            prog_bar=True,
+        )
+        return loss
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        """
+        Optimizing function used to reduce the loss, so that the predicted
+        mask gets as close as possible to the groundtruth mask.
+
+        Using the Adam optimizer with a learning rate of 0.01. See:
+
+        - Kingma, D. P., & Ba, J. (2017). Adam: A Method for Stochastic
+          Optimization. ArXiv:1412.6980 [Cs]. http://arxiv.org/abs/1412.6980
+
+        Documentation at:
+        https://lightning.ai/docs/pytorch/2.0.2/common/lightning_module.html#configure-optimizers
+        """
+        return torch.optim.Adam(params=self.parameters(), lr=0.01)

--- a/chabud/tests/test_model.py
+++ b/chabud/tests/test_model.py
@@ -1,7 +1,7 @@
 """
 Tests for ChaBuDNet.
 
-Based loosely on Pytorch Lightning's testing method described at
+Based loosely on Lightning's testing method described at
 https://github.com/Lightning-AI/lightning/blob/2.0.2/.github/CONTRIBUTING.md#how-to-add-new-tests
 """
 import lightning as L

--- a/chabud/tests/test_model.py
+++ b/chabud/tests/test_model.py
@@ -1,0 +1,53 @@
+"""
+Tests for ChaBuDNet.
+
+Based loosely on Pytorch Lightning's testing method described at
+https://github.com/Lightning-AI/lightning/blob/2.0.2/.github/CONTRIBUTING.md#how-to-add-new-tests
+"""
+import lightning as L
+import pytest
+import torch
+import torchdata
+import torchdata.dataloader2
+
+from chabud.model import ChaBuDNet
+
+
+# %%
+@pytest.fixture(scope="function", name="datapipe")
+def fixture_datapipe() -> torchdata.datapipes.iter.IterDataPipe:
+    """
+    A torchdata DataPipe with random data to use in the tests.
+    """
+    datapipe = torchdata.datapipes.iter.IterableWrapper(
+        iterable=[
+            (
+                torch.randn(8, 12, 512, 512).to(dtype=torch.int16),  # pre_image
+                torch.randn(8, 12, 512, 512).to(dtype=torch.int16),  # post_image
+                torch.randint(
+                    low=0, high=1, size=(8, 512, 512), dtype=torch.uint8
+                ),  # mask
+                [{"uuid": None} for _ in range(8)],  # metadata
+            )
+        ]
+    )
+    return datapipe
+
+
+# %%
+def test_model(datapipe):
+    """
+    Run a full train, val, test and prediction loop using 1 batch.
+    """
+    # Get some random data
+    dataloader = torchdata.dataloader2.DataLoader2(datapipe=datapipe)
+
+    # Initialize Model
+    model: L.LightningModule = ChaBuDNet()
+
+    # Training
+    trainer: L.Trainer = L.Trainer(accelerator="auto", devices=1, fast_dev_run=True)
+    trainer.fit(model=model, train_dataloaders=dataloader)
+
+    # Test
+    # TODO


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Minimum-ish Viable Product, or the first iteration of the ChaBuDNet model!

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Created a LightningModule under `chabud/model.py`
  - Model architecture: 2 Convolutional layers sandwiching a SiLU activation.
  - Loss function: BinaryCrossEntropy with logits loss
  - Metric: Intersection over Union (IoU) from torchmetrics
  - Optimizer: Adam
- Added a basic unit test to ensure a single train/val loop works.
- Gitignored some checkpoint and log files 

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `python -m pytest chabud/tests/test_model.py`

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
Adapted from previous work at:
- https://github.com/weiji14/s2s2net/blob/main/s2s2net/model.py
- https://gitlab.com/frontierdevelopmentlab/2022-us-sarchangedetection/deepslide/-/blob/main/src/models/contrastive_learning.py
