### PR TITLE
:technologist: Implement test_step to generate submission CSV file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 # Data files and folders
 data/**
 !data/**/
+**/*.csv
 
 # Lightning checkpoints
 checkpoints/*.ckpt

--- a/README.md
+++ b/README.md
@@ -86,5 +86,11 @@ To train the model for a hundred epochs:
 
     python trainer.py fit --trainer.max_epochs=100
 
+To generate the CSV file of predicted masks on the validation set for
+[submission](https://huggingface.co/datasets/chabud-team/chabud-ecml-pkdd2023/blob/main/create_sample_submission.py)
+to https://huggingface.co/spaces/competitions/ChaBuD-ECML-PKDD2023.
+
+    python trainer.py test --model.submission_filepath=submission.csv
+
 More options can be found using `python trainer.py fit --help`, or at the
 [LightningCLI docs](https://lightning.ai/docs/pytorch/2.0.2/cli/lightning_cli.html).

--- a/chabud/datapipe.py
+++ b/chabud/datapipe.py
@@ -207,7 +207,7 @@ class ChaBuDDataPipeModule(L.LightningDataModule):
 
         # Step 3 - Split chips into train/val sets based on fold attribute
         dp_val, dp_train = dp_chip.demux(
-            num_instances=2, classifier_fn=_train_val_fold, buffer_size=1024
+            num_instances=2, classifier_fn=_train_val_fold, buffer_size=2048
         )
 
         # Step 4 - Convert from xarray.Dataset to tuple of torch.Tensor objects
@@ -233,5 +233,11 @@ class ChaBuDDataPipeModule(L.LightningDataModule):
     def val_dataloader(self) -> torchdata.dataloader2.DataLoader2:
         """
         Loads the data used in the validation loop.
+        """
+        return torchdata.dataloader2.DataLoader2(datapipe=self.datapipe_val)
+
+    def test_dataloader(self) -> torchdata.dataloader2.DataLoader2:
+        """
+        Loads the data used in the test loop.
         """
         return torchdata.dataloader2.DataLoader2(datapipe=self.datapipe_val)

--- a/chabud/model.py
+++ b/chabud/model.py
@@ -4,10 +4,12 @@ ChaBuDNet model architecture code.
 Code structure adapted from Lightning project seed at
 https://github.com/Lightning-AI/deep-learning-project-template
 """
-
 import lightning as L
+import numpy as np
+import pandas as pd
 import torch
 import torchmetrics
+import trimesh.voxel.runlength
 
 
 # %%
@@ -19,7 +21,7 @@ class ChaBuDNet(L.LightningModule):
     Implemented using Lightning 2.0.
     """
 
-    def __init__(self, lr: float = 0.001):
+    def __init__(self, lr: float = 0.001, submission_filepath: str = "submission.csv"):
         """
         Define layers of the ChaBuDNet model.
 
@@ -27,6 +29,11 @@ class ChaBuDNet(L.LightningModule):
         ----------
         lr : float
             The learning rate for the Adam optimizer. Default is 0.001.
+
+        submission_filepath : str
+            Filepath of the CSV file to save the output used for submitting to
+            HuggingFace after running the test_step. Default is
+            `submission.csv`.
         """
         super().__init__()
 
@@ -126,6 +133,65 @@ class ChaBuDNet(L.LightningModule):
             prog_bar=True,
         )
         return loss
+
+    def test_step(
+        self,
+        batch: tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict],
+        batch_idx: int,
+    ) -> torch.Tensor:
+        """
+        Logic for the neural network's test loop.
+
+        Produces a CSV table for submission. Columns are 'id', 'index', and
+        'rle_mask', where 'rle_mask' is a binary run length encoding of the
+        burned area mask.
+
+        References:
+        - https://huggingface.co/datasets/chabud-team/chabud-ecml-pkdd2023/blob/main/create_sample_submission.py
+        - https://trimsh.org/trimesh.voxel.runlength.html#trimesh.voxel.runlength.dense_to_brle
+        """
+        dtype = torch.float16 if "16" in self.trainer.precision else torch.float32
+        pre_img, post_img, mask, metadata = batch
+
+        # Pass the image through neural network model to get predicted images
+        x: torch.Tensor = torch.concat(tensors=[pre_img, post_img], dim=1).to(
+            dtype=dtype
+        )
+        # assert x.shape == (32, 24, 512, 512)
+        y_hat: torch.Tensor = self(x=x)
+        # assert y_hat.shape == mask.shape == (32, 512, 512)
+
+        # Format predicted mask as binary run length encoding vector
+        result: list = []
+        for pred_mask, uuid in zip(y_hat, pd.DataFrame(metadata)["uuid"]):
+            flat_binary_mask: np.ndarray = (
+                torch.sigmoid(input=pred_mask).to(bool).flatten().cpu().numpy()
+            )
+            brle: np.ndarray = trimesh.voxel.runlength.dense_to_brle(
+                dense_data=flat_binary_mask
+            )
+            encoded_prediction: dict = {
+                "id": uuid,
+                "rle_mask": brle,
+                "index": torch.arange(len(brle)),
+            }
+            result.append(pd.DataFrame(data=encoded_prediction))
+
+        # Write results to CSV. Create file on first batch, append afterwards
+        df_submission: pd.DataFrame = pd.concat(objs=result)
+        df_submission.to_csv(
+            path_or_buf=self.hparams.submission_filepath,
+            index=False,
+            mode="w" if batch_idx == 0 else "a",
+            header=True if batch_idx == 0 else False,
+        )
+
+        # Log validation loss and metrics
+        metric: torch.Tensor = self.iou(preds=y_hat, target=mask)
+        self.log_dict(
+            dictionary={"test/iou": metric}, on_step=True, on_epoch=False, prog_bar=True
+        )
+        return metric
 
     def configure_optimizers(self) -> torch.optim.Optimizer:
         """

--- a/chabud/tests/test_model.py
+++ b/chabud/tests/test_model.py
@@ -4,7 +4,11 @@ Tests for ChaBuDNet.
 Based loosely on Lightning's testing method described at
 https://github.com/Lightning-AI/lightning/blob/2.0.2/.github/CONTRIBUTING.md#how-to-add-new-tests
 """
+import os
+import tempfile
+
 import lightning as L
+import pandas as pd
 import pytest
 import torch
 import torchdata
@@ -49,5 +53,12 @@ def test_model(datapipe):
     trainer: L.Trainer = L.Trainer(accelerator="auto", devices=1, fast_dev_run=True)
     trainer.fit(model=model, train_dataloaders=dataloader)
 
-    # Test
-    # TODO
+    # Test/Evaluation
+    with tempfile.NamedTemporaryFile(suffix=".csv") as tmpfile:
+        trainer.model.hparams.submission_filepath = tmpfile.name
+        trainer.test(model=model, dataloaders=dataloader)
+
+        assert os.path.exists(tmpfile.name)
+        df: pd.DataFrame = pd.read_csv(tmpfile.name)
+        assert len(df) > 0
+        assert df.columns.to_list() == ["id", "rle_mask", "index"]

--- a/chabud/tests/test_trainer.py
+++ b/chabud/tests/test_trainer.py
@@ -10,7 +10,7 @@ from trainer import cli_main
 
 
 # %%
-@pytest.mark.parametrize("subcommand", ["fit", "validate"])
+@pytest.mark.parametrize("subcommand", ["fit", "validate", "test"])
 def test_cli_main(subcommand, capsys):
     """
     Ensure that running `python trainer.py` works with the subcommands `fit`

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -17,7 +17,7 @@ metadata:
   - url: nodefaults
     used_env_vars: []
   content_hash:
-    linux-64: 2c33f67a412cccd922ae46cf63e544e879d4beacf84226018b680f060f1b39a3
+    linux-64: 8754d90e55c27af20410f48ceb9cfa353229f08064c14bbc2cf23b73355eb5ec
   platforms:
   - linux-64
   sources:
@@ -629,16 +629,16 @@ package:
   version: 1.0.10
 - category: main
   dependencies:
-    libgcc-ng: '>=9.3.0'
+    libgcc-ng: '>=12'
   hash:
-    md5: bf6f803a544f26ebbdc3bfff272eb179
-    sha256: 9e9b70c24527289ac7ae31925d1eb3b0c1e9a78cb7b8f58a3110cc8bbfe51c26
+    md5: 2c80dc38fface310c9bd81b17037fee5
+    sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
   manager: conda
   name: xorg-libxau
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.9-h7f98852_0.tar.bz2
-  version: 1.0.9
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+  version: 1.0.11
 - category: main
   dependencies:
     libgcc-ng: '>=9.3.0'
@@ -892,19 +892,19 @@ package:
   version: 1.10.0
 - category: main
   dependencies:
-    libgcc-ng: '>=9.4.0'
+    libgcc-ng: '>=12'
     pthread-stubs: ''
     xorg-libxau: ''
     xorg-libxdmcp: ''
   hash:
-    md5: b3653fdc58d03face9724f602218a904
-    sha256: 8d5d24cbeda9282dd707edd3156e5fde2e3f3fe86c802fa7ce08c8f1e803bfd9
+    md5: 33277193f5b92bad9fdd230eb700929c
+    sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
   manager: conda
   name: libxcb
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
-  version: '1.13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+  version: '1.15'
 - category: main
   dependencies:
     icu: '>=72.1,<73.0a0'
@@ -1246,18 +1246,18 @@ package:
 - category: main
   dependencies:
     libgcc-ng: '>=12'
-    libxcb: '>=1.13,<1.14.0a0'
+    libxcb: '>=1.15,<1.16.0a0'
     xorg-kbproto: ''
     xorg-xextproto: '>=7.3.0,<8.0a0'
     xorg-xproto: ''
   hash:
-    md5: ea8fbfeb976ac49cbeb594e985393514
-    sha256: 3c6862a01a39cdea3870b132706ad7256824299947a3a94ae361d863d402d704
+    md5: 52d09ea80a42c0466214609ef0a2d62d
+    sha256: 26e5c72def9f1b191afea84aa2d09622d34b2f547a446eac201ecf894521e5ee
   manager: conda
   name: xorg-libx11
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.4-h0b41bf4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.4-h8ee46fc_1.conda
   version: 1.8.4
 - category: main
   dependencies:
@@ -2536,6 +2536,18 @@ package:
   version: 2023.5.2
 - category: main
   dependencies:
+    python: '>=3'
+  hash:
+    md5: e6573ac68718f17b9d4f5c8eda3190f2
+    sha256: ec1cfe0b7dc55a22223562cad799e0b16d122dab611c9923b6068d27a784ba2f
+  manager: conda
+  name: typing
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-3.10.0.0-pyhd8ed1ab_0.tar.bz2
+  version: 3.10.0.0
+- category: main
+  dependencies:
     python: '>=3.7'
   hash:
     md5: 43e7d9e50261fb11deb76e17d8431aac
@@ -2562,14 +2574,14 @@ package:
   dependencies:
     python: '>=3.7'
   hash:
-    md5: 2a914654b9ade742049dab13e29571c6
-    sha256: 7a2c359d12a13e505b74cd82686f98379113c9b4be01f6685167ba137b286127
+    md5: bfe7e7cd1476092f51efbcde15dfb110
+    sha256: 85310b382c4220d7846fa8f046216fd722b88db07991f07bd7decdf2e5dc3446
   manager: conda
   name: websocket-client
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.5.1-pyhd8ed1ab_0.conda
-  version: 1.5.1
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.5.2-pyhd8ed1ab_0.conda
+  version: 1.5.2
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -2725,6 +2737,19 @@ package:
   version: 2.12.1
 - category: main
   dependencies:
+    python: '>=3.6'
+    typing: '>=3.6'
+  hash:
+    md5: 0e1df3978dd516e20ef88c86d51e5432
+    sha256: 1d86eafb5e9ed078f891e12b46692d786723652907dfb01b047c7da31f92b862
+  manager: conda
+  name: backports.cached-property
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/backports.cached-property-1.0.2-pyhd8ed1ab_0.tar.bz2
+  version: 1.0.2
+- category: main
+  dependencies:
     backports: ''
     python: '>=3.6'
     setuptools: ''
@@ -2785,9 +2810,9 @@ package:
     freetype: '>=2.12.1,<3.0a0'
     icu: '>=72.1,<73.0a0'
     libgcc-ng: '>=12'
-    libglib: '>=2.74.1,<3.0a0'
+    libglib: '>=2.76.2,<3.0a0'
     libpng: '>=1.6.39,<1.7.0a0'
-    libxcb: '>=1.13,<1.14.0a0'
+    libxcb: '>=1.15,<1.16.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     pixman: '>=0.40.0,<1.0a0'
     xorg-libice: ''
@@ -2797,13 +2822,13 @@ package:
     xorg-libxrender: ''
     zlib: ''
   hash:
-    md5: 0c944213e40c9e4aa32292776b9c6903
-    sha256: 0be3064cb30e3e69a47370abae85b2780cd81fbca00cbd17076d40c0f6302fdb
+    md5: c1dd96500b9b1a75e9e511931f415cbc
+    sha256: 1fffecc684c26e0f1aed6d9857ad0f2abfe3a849977f718ad82366c68c7a9a36
   manager: conda
   name: cairo
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.16.0-h35add3b_1015.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.16.0-hbbf8b49_1016.conda
   version: 1.16.0
 - category: main
   dependencies:
@@ -3266,6 +3291,19 @@ package:
   version: 4.65.0
 - category: main
   dependencies:
+    numpy: ''
+    python: '>=2.7'
+  hash:
+    md5: 1d142ace092d55368f4d6437b2547056
+    sha256: d1a02c5c89b993210a2b42fe85990f0060087a7e97ba87a30f1b316159e2cd18
+  manager: conda
+  name: trimesh
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/trimesh-3.21.7-pyhd8ed1ab_0.conda
+  version: 3.21.7
+- category: main
+  dependencies:
     typing_extensions: 4.5.0 pyha770c72_0
   hash:
     md5: b3c594fde1a80a1fc3eb9cc4a5dfe392
@@ -3535,29 +3573,29 @@ package:
 - category: main
   dependencies:
     python: '>=3.7'
-    typing-extensions: '>=4.4'
+    typing-extensions: '>=4.5'
   hash:
-    md5: 0b4cc3f8181b0d8446eb5387d7848a54
-    sha256: 5d469cd150e4413b15eedb66bdc7a3831a4249e2e5646b8c9dcdf713e35fc598
+    md5: e2be672aece1f060adf7154f76531a35
+    sha256: d7845c01a9ee5a224cc9242782befed7d12dc6aac1103650ec87917b20f3579e
   manager: conda
   name: platformdirs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.6.2-pyhd8ed1ab_0.conda
-  version: 2.6.2
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.5.1-pyhd8ed1ab_0.conda
+  version: 3.5.1
 - category: main
   dependencies:
     importlib-metadata: '>=1.7.0'
     python: '>=3.7'
   hash:
-    md5: 57569be9bdfc6baf2b28ee4ae5c6ed3a
-    sha256: cde0093926a36b90801164cdc0e084e2a1ffa343796d39df75dfeb8f529f9300
+    md5: 17c7b3297333fe0b1196541a4a766915
+    sha256: 388bcb1395570b8e4e7334429371691430a06732a63ee8d9ad1256892727989f
   manager: conda
   name: poetry-core
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/poetry-core-1.5.2-pyhd8ed1ab_0.conda
-  version: 1.5.2
+  url: https://conda.anaconda.org/conda-forge/noarch/poetry-core-1.6.0-pyhd8ed1ab_0.conda
+  version: 1.6.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -3914,19 +3952,18 @@ package:
 - category: main
   dependencies:
     distlib: <1,>=0.3.6
-    filelock: <4,>=3.4.1
-    importlib-metadata: '>=4.8.3'
-    platformdirs: <4,>=2.4
-    python: '>=3.7'
+    filelock: <4,>=3.11
+    platformdirs: <4,>=3.2
+    python: '>=3.8'
   hash:
-    md5: a5c4387ca0742230272f98e08120ac23
-    sha256: 40f01e80a025aa52cc72ba2d6dc5803b02e1b2e5dbcd158329486517f1867cce
+    md5: a920e114c4c2ced2280e266da65ab5e6
+    sha256: 13d667887ea08b6d1fe2eb09d2d737f9af7343735d3bfa5ffaa3f67eec8eaff7
   manager: conda
   name: virtualenv
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.21.1-pyhd8ed1ab_0.conda
-  version: 20.21.1
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.23.0-pyhd8ed1ab_0.conda
+  version: 20.23.0
 - category: main
   dependencies:
     numpy: '>=1.21'
@@ -3934,14 +3971,14 @@ package:
     pandas: '>=1.4'
     python: '>=3.9'
   hash:
-    md5: 1412ff164b976fc6d8f8d7afc3b09240
-    sha256: ad17565679cebbac840f0761ee7bb7f6fb2d7f1935acbe274be81a3240973a2b
+    md5: 254b5553bed6adf404ac09fa07cb54da
+    sha256: cd98280dfb226ebb26b7d90da8f3342ecba66ea521b3df27e7a75bc709905502
   manager: conda
   name: xarray
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.4.2-pyhd8ed1ab_0.conda
-  version: 2023.4.2
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.5.0-pyhd8ed1ab_0.conda
+  version: 2023.5.0
 - category: main
   dependencies:
     aiofiles: '>=22.1.0,<23'
@@ -4129,14 +4166,14 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,<1.27'
   hash:
-    md5: e093f475f92735911cf512e7ffcd6de3
-    sha256: 0645645681bfee6fc5ef3c3d86b03da502f47f10a00d69c1361b84ec5544715e
+    md5: c3c8319f182f71910059a6724721f1a4
+    sha256: ccfa8a30773f41887d08bbcaa84d680c38f96748d2f7cc407fba21760a11ca6f
   manager: conda
   name: botocore
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.29.136-pyhd8ed1ab_0.conda
-  version: 1.29.136
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.29.137-pyhd8ed1ab_0.conda
+  version: 1.29.137
 - category: main
   dependencies:
     certifi: ''
@@ -4333,14 +4370,14 @@ package:
     uvicorn: ''
     websocket-client: ''
   hash:
-    md5: 12b743694a8d8952b63d2fb18ddbd45e
-    sha256: f7176107dd549375ce39c54137214200f5c27c29f352cb541fa8f516948704b6
+    md5: fd99cc369aa3c6c66493d4d278338af5
+    sha256: 2047f4dcd4531f6cd2f87a80fef0d265f663e011931af746b2725f7d567ce016
   manager: conda
   name: lightning-cloud
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/lightning-cloud-0.5.35-pyhd8ed1ab_0.conda
-  version: 0.5.35
+  url: https://conda.anaconda.org/conda-forge/noarch/lightning-cloud-0.5.36-pyhd8ed1ab_0.conda
+  version: 0.5.36
 - category: main
   dependencies:
     beautifulsoup4: ''
@@ -4407,16 +4444,16 @@ package:
 - category: main
   dependencies:
     python: '>=3.6'
-    requests: '>=2.0.1,<=3.0.0'
+    requests: '>=2.0.1,<3.0.0'
   hash:
-    md5: a4cd20af9711434f89d1ec0d2b3ae6ba
-    sha256: 7f4c9c829add7a65a1f536c30539c541bb3c9dddbd03d7ba318f224b4add0d6d
+    md5: 99c98318c8646b08cc764f90ce98906e
+    sha256: 20eaefc5dba74ff6c31e537533dde59b5b20f69e74df49dff19d43be59785fa3
   manager: conda
   name: requests-toolbelt
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-0.10.1-pyhd8ed1ab_0.tar.bz2
-  version: 0.10.1
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_0.conda
+  version: 1.0.0
 - category: main
   dependencies:
     botocore: '>=1.12.36,<2.0a.0'
@@ -4432,7 +4469,7 @@ package:
   version: 0.6.1
 - category: main
   dependencies:
-    botocore: 1.29.136
+    botocore: 1.29.137
     colorama: '>=0.2.5,<0.4.5'
     docutils: '>=0.10,<0.17'
     python: '>=3.11,<3.12.0a0'
@@ -4441,14 +4478,14 @@ package:
     rsa: '>=3.1.2,<4.8'
     s3transfer: '>=0.6.0,<0.7.0'
   hash:
-    md5: 236d91b1c0fdeca91240ef337f9c54fd
-    sha256: 83e5a7885e0c592779636b4b81cae9c3181cf2a26287186cc799057b9482464c
+    md5: 054022f23d6887682162fa0052ed1933
+    sha256: 36c0cd41c37c5074faa34e418b9b952d19c407daaa3bdbbbd44e6250b1483b5e
   manager: conda
   name: awscli
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.27.136-py311h38be061_0.conda
-  version: 1.27.136
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.27.137-py311h38be061_0.conda
+  version: 1.27.137
 - category: main
   dependencies:
     cachecontrol: 0.12.11 pyhd8ed1ab_1
@@ -4509,6 +4546,7 @@ package:
 - category: main
   dependencies:
     __linux: ''
+    backports.cached-property: '>=1.0.2,<2.0.0'
     cachecontrol: '>=0.12.9,<0.13.0'
     cleo: '>=2.0.0,<3.0.0'
     crashtest: '>=0.4.1,<0.5.0'
@@ -4522,30 +4560,30 @@ package:
     packaging: '>=20.4'
     pexpect: '>=4.7.0,<5.0.0'
     pkginfo: '>=1.9.4,<2.0'
-    platformdirs: '>=2.5.2,<3.0.0'
-    poetry-core: 1.5.2.*
-    poetry-plugin-export: '>=1.3.0,<2.0.0'
+    platformdirs: '>=3.0.0,<4.0.0'
+    poetry-core: 1.6.0.*
+    poetry-plugin-export: '>=1.3.1,<2.0.0'
     pyproject_hooks: '>=1.0.0,<2.0.0'
     python: '>=3.7,<4.0'
     python-build: '>=0.10.0,<0.11.0'
     python-installer: '>=0.7.0,<0.8.0'
     requests: '>=2.18,<3.0'
-    requests-toolbelt: '>=0.9.1,<0.11.0'
+    requests-toolbelt: '>=0.9.1,<2'
     shellingham: '>=1.5,<2.0'
     tomli: '>=2.0.1,<3.0.0'
-    tomlkit: '>=0.11.1,<1.0.0,!=0.11.2,!=0.11.3'
+    tomlkit: '>=0.11.4,<1.0.0'
     trove-classifiers: '>=2022.5.19'
     urllib3: '>=1.26.0,<2.0.0'
-    virtualenv: '>=20.4.3,<21.0.0,!=20.4.5,!=20.4.6'
+    virtualenv: '>=20.22.0,<21.0.0'
   hash:
-    md5: 4f54033839290559f0693169c92c8500
-    sha256: cf14bef85c5c3d3d24298507d52e2213423597a1fc2e78d3d8bcfd9449d92809
+    md5: f279aa7b2d24b34dcae91d2938f7f5fd
+    sha256: d02ffa7ed5aaf391eb6bd9cd871a18f3606924078fc69f619919254a4aa366ec
   manager: conda
   name: poetry
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/poetry-1.4.2-linux_pyhd8ed1ab_0.conda
-  version: 1.4.2
+  url: https://conda.anaconda.org/conda-forge/noarch/poetry-1.5.0-linux_pyhd8ed1ab_0.conda
+  version: 1.5.0
 - category: main
   dependencies:
     cachecontrol-with-filecache: '>=0.12.9'

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - python=3.11.3
   - python-graphviz=0.20.1
   - torchdata=0.6.0
+  - trimesh=3.21.7
   - xarray-datatree=0.0.12
   - pip:
       - typeshed-client==2.3.0


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Scripts to produce CSV files for submission to HuggingFace!

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- [x] Convert the predicted masks on the validation set to binary run length encoding format, and format it into a dataframe table.
- [x] Documented how to create the output CSV file with a one-liner `python trainer.py test` command
- [x] Added unit tests to ensure that the implementation in ChaBuDNet.test_step works

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `python trainer.py test --model.submission_filepath=submission.csv` in the command-line

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->

Resources used to create the scripts in this PR:
-  Sample submission.csv file - https://huggingface.co/datasets/chabud-team/chabud-ecml-pkdd2023/blob/main/sample_submission.csv
- Official script to generate CSV file - https://huggingface.co/datasets/chabud-team/chabud-ecml-pkdd2023/blob/main/create_sample_submission.py
- Note at https://huggingface.co/spaces/competitions/ChaBuD-ECML-PKDD2023 under the `Dataset` -> `Evaluation` -> `How to submit`
  > The submissions must be in csv format with three columns: id, index, rle_mask. Remember to “explode” index and rle_mask, having a single value for each line. 
- Documentation about Binary Run Length Encoding (BRLE) format - https://trimsh.org/trimesh.voxel.runlength.html#trimesh.voxel.runlength.dense_to_brle
