### PR TITLE
:technologist: Add one-click button to launch on SageMaker Studio Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Launch on regular [Binder](https://mybinder.readthedocs.io/en/latest).
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/chabud2023/main)
 
+Launch on [SageMaker Studio Lab](https://studiolab.sagemaker.aws).
+
+[![Open in SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/developmentseed/chabud2023/blob/main/train_chabud.ipynb)
+
 ## Installation
 
 ### Basic

--- a/train_chabud.ipynb
+++ b/train_chabud.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c82359ab-bdd3-484e-9bf9-910ad7b2d17d",
+   "metadata": {},
+   "source": [
+    "# Change detection for Burned area Delineation (ChaBuD)\n",
+    "\n",
+    "Welcome to the ChaBuD repo!\n",
+    "Follow the instructions in the [README.md](./README.md)\n",
+    "file to get started on running the change detection model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11094178-9a3d-4f0e-b6e2-b783f49c6bf7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#!python trainer.py test --help"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Quickstart button to launch into a JupyterHub instance on Amazon SageMaker Studio Lab. Instructions at https://github.com/aws/studio-lab-examples/tree/4fda43e595196435ec9c6e456f8a1cbe53d6747c/open-in-studio-lab. Added a minimal train_chabud.ipynb as the entrypoint notebook.

## What I am changing
<!-- What were the high-level goals of the change? -->
- Make it easy to run the ChaBuD model on [SageMaker Studio Lab](https://studiolab.sagemaker.aws)!

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Done by following instructions at https://github.com/aws/studio-lab-examples/tree/4fda43e595196435ec9c6e456f8a1cbe53d6747c/open-in-studio-lab.
  1. Add a button to the main README.md with the markdown `[![Open in SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/developmentseed/chabud2023/blob/main/train_chabud.ipynb)`
  2. Include a `train_chabud.ipynb` Jupyter notebook as an entrypoint, since SageMaker Studio Lab doesn't support launching into markdown files yet (see https://github.com/aws/studio-lab-examples/issues/76).

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Click on [![Open in SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/developmentseed/chabud2023/blob/quickstart-sagemaker-button/train_chabud.ipynb)

Note: Need a SageMaker Studio Lab account. Also, the above button only works when this PR is unmerged and the `quickstart-sagemaker-button` branch exists. 

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->

References:
- https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lab.html
- https://github.com/aws/studio-lab-examples/tree/4fda43e595196435ec9c6e456f8a1cbe53d6747c/open-in-studio-lab
- https://github.com/aws/studio-lab-examples/tree/24e1ed0741cc0ff55d532f3fd396e50111b2df08#custom-environments